### PR TITLE
feat: save and restore php session

### DIFF
--- a/src-mmlc/Classes/Controller.php
+++ b/src-mmlc/Classes/Controller.php
@@ -154,7 +154,7 @@ class Controller extends StdController
         \Stripe\Stripe::setApiKey($this->config->apiSandboxSecret);
 
         // You can find your endpoint's secret in your webhook settings
-        $endpointSecret = 'whsec_7d66a166a5ac61787f238ebfdc60fa76d425277bde4f6db9159befbbdefd9e42';
+        $endpointSecret = 'whsec_';
 
         $payload   = @file_get_contents('php://input');
         $sigHeader = $_SERVER['HTTP_STRIPE_SIGNATURE'];

--- a/src-mmlc/Classes/Controller.php
+++ b/src-mmlc/Classes/Controller.php
@@ -63,6 +63,8 @@ class Controller extends StdController
         require_once DIR_WS_FUNCTIONS . 'sessions.php';
         include_once DIR_WS_MODULES . 'set_session_and_cookie_parameters.php';
 
+        $domain = HTTPS_SERVER;
+
         /**
          * We need to save the current PHP session, as it may have already expired if the customer takes a long time
          * with the Stripe payment process. When the PHP session times out, the customer has paid, but no order is
@@ -76,14 +78,8 @@ class Controller extends StdController
             die('Can not create a Stripe session because we have no order Obj');
         }
 
-        // var_dump($order);
-        // die();
-
         Stripe::setApiKey($this->config->apiSandboxSecret);
         header('Content-Type: application/json');
-
-        $domain = HTTPS_SERVER;
-
 
         $priceData = [
             'currency'     => 'eur',
@@ -100,15 +96,14 @@ class Controller extends StdController
          * @link https://stripe.com/docs/api/checkout/sessions/object
          */
         $checkoutSession = StripeSession::create([
-            'line_items'  => [[
-                # Provide the exact Price ID (e.g. pr_1234) of the product you want to sell
-                //'price' => 'price_1NBDB1JIsfvAtVBddfc2gRn6',
+            'line_items'          => [[
                 'price_data' => $priceData,
                 'quantity'   => 1,
             ]],
-            'mode'        => 'payment',
-            'success_url' => $domain . '/rth_stripe.php?action=success&session_id={CHECKOUT_SESSION_ID}',
-            'cancel_url'  => $domain . '/rth_stripe.php?action=cancel',
+            'client_reference_id' => $sessionId,
+            'mode'                => 'payment',
+            'success_url'         => $domain . '/rth_stripe.php?action=success&session_id={CHECKOUT_SESSION_ID}',
+            'cancel_url'          => $domain . '/rth_stripe.php?action=cancel',
         ]);
 
         header("HTTP/1.1 303 See Other");
@@ -122,20 +117,12 @@ class Controller extends StdController
 
         $stripe = new \Stripe\StripeClient($this->config->apiSandboxSecret);
 
-        //$phpSession = new PhpSession();
-        //$order = $phpSession->getOrder();
-        //dd($order);
-
-        //client_reference_id
-        //var_dump($_GET['session_id']);
-
         try {
-            $session = $stripe->checkout->sessions->retrieve($_GET['session_id']);
-            //dd($session);
-            //$customer = $stripe->customers->retrieve($session->customer);
-            //echo "<h1>Thanks for your order, $customer->name!</h1>";
-            //http_response_code(200);
-            //dd('The order was successfully paid.');
+            $session      = $stripe->checkout->sessions->retrieve($_GET['session_id']);
+            $phpSessionId = $session->client_reference_id;
+
+            $phpSession = new PhpSession();
+            $phpSession->load($phpSessionId);
 
             // TODO: Check if the order was realy paid, if possible
             // TODO: Load the php session if the payment process took too long
@@ -161,12 +148,33 @@ class Controller extends StdController
      */
     protected function invokeReceiveHook(): void
     {
-        $payload = @file_get_contents('php://input');
-        file_put_contents('stripe_webhook_log.txt', $payload, FILE_APPEND);
+        //$payload = @file_get_contents('php://input');
+        //file_put_contents('stripe_webhook_log.txt', $payload, FILE_APPEND);
 
-        // TODO: Check if the webhook comes from stripe.
+        \Stripe\Stripe::setApiKey($this->config->apiSandboxSecret);
+
+        // You can find your endpoint's secret in your webhook settings
+        $endpointSecret = 'whsec_7d66a166a5ac61787f238ebfdc60fa76d425277bde4f6db9159befbbdefd9e42';
+
+        $payload   = @file_get_contents('php://input');
+        $sigHeader = $_SERVER['HTTP_STRIPE_SIGNATURE'];
+        $event     = null;
+
+        try {
+            $event = \Stripe\Webhook::constructEvent($payload, $sigHeader, $endpointSecret);
+        } catch (\UnexpectedValueException $e) {
+            // Invalid payload
+            http_response_code(400);
+            exit();
+        } catch (\Stripe\Exception\SignatureVerificationException $e) {
+            // Invalid signature
+            http_response_code(400);
+            exit();
+        }
 
         // TODO: Change the status of the order (e.g. to paid)
+        file_put_contents('stripe_webhook_log.txt', $payload, FILE_APPEND);
+        file_put_contents('stripe_webhook_log.txt', print_r($event, true), FILE_APPEND);
 
         http_response_code(200);
     }

--- a/src-mmlc/Classes/Repository.php
+++ b/src-mmlc/Classes/Repository.php
@@ -20,6 +20,17 @@ namespace RobinTheHood\Stripe\Classes;
  */
 class Repository
 {
+    public function createRthStripePhpSession()
+    {
+        xtc_db_query("CREATE TABLE `rth_stripe_php_session` (
+            `id` varchar(32) NOT NULL,
+            `created` datetime DEFAULT NULL,
+            `data` longtext DEFAULT NULL,
+            PRIMARY KEY (`id`)
+          );
+        ");
+    }
+
     public function getRthStripePhpSessionById(string $id)
     {
         $sql = "SELECT * FROM rth_stripe_php_session WHERE id='$id'";

--- a/src-mmlc/Classes/Repository.php
+++ b/src-mmlc/Classes/Repository.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Stripe integration for modified
+ *
+ * You can find informations about system classes and development at:
+ * https://docs.module-loader.de
+ *
+ * @author  Robin Wieschendorf <mail@robinwieschendorf.de>
+ * @author  Jay Trees <stripe@grandels.email>
+ * @link    https://github.com/RobinTheHood/modified-stripe/
+ */
+
+declare(strict_types=1);
+
+namespace RobinTheHood\Stripe\Classes;
+
+/**
+ * In this class we outsource all queries to the database. So we only need SQL in this file.
+ */
+class Repository
+{
+    public function getRthStripePhpSessionById(string $id)
+    {
+        $sql = "SELECT * FROM rth_stripe_php_session WHERE id='$id'";
+
+        $query = xtc_db_query($sql);
+
+        $row = xtc_db_fetch_array($query);
+        if (!isset($row['id'])) {
+            return false;
+        }
+
+        return $row;
+    }
+
+    public function insertRthStripePhpSession(string $id, string $data)
+    {
+        $sql = "INSERT INTO rth_stripe_php_session (
+            `id`, `data`, `created`
+        ) VALUES (
+            '$id', '$data', NOW()
+        )";
+
+        xtc_db_query($sql);
+    }
+}

--- a/src-mmlc/Classes/Session.php
+++ b/src-mmlc/Classes/Session.php
@@ -63,7 +63,10 @@ class Session
         }
 
         $sessionData = serialize($_SESSION);
-        // TODO ...
+        $sessionData = base64_encode($sessionData);
+
+        $repo = new Repository();
+        $repo->insertRthStripePhpSession($sessionId, $sessionData);
 
         return $sessionId;
     }
@@ -71,16 +74,19 @@ class Session
     /**
      * The method should later load a PHP session from a database table.
      */
-    private function load(string $sessionId)
+    public function load(string $sessionId)
     {
-        $sessionData = '';
+        $repo = new Repository();
 
-        $_SESSION = unserialize($sessionData);
-        // TODO ...
+        $phpSession  = $repo->getRthStripePhpSessionById($sessionId);
+        $sessionData = base64_decode($phpSession['data']);
+        $session     = unserialize($sessionData);
+
+        $_SESSION = $session;
     }
 
     private function createSessionId(): string
     {
-        return uniqid();
+        return 'sid_' . uniqid();
     }
 }

--- a/src/includes/modules/payment/payment_rth_stripe.php
+++ b/src/includes/modules/payment/payment_rth_stripe.php
@@ -18,7 +18,7 @@
 declare(strict_types=1);
 
 use RobinTheHood\ModifiedStdModule\Classes\Configuration;
-use RobinTheHood\Stripe\Classes\{Order, Session, Constants, PaymentModule};
+use RobinTheHood\Stripe\Classes\{Order, Session, Constants, PaymentModule, Repository};
 use Stripe\WebhookEndpoint;
 
 class payment_rth_stripe extends PaymentModule
@@ -114,13 +114,8 @@ class payment_rth_stripe extends PaymentModule
         $this->addConfiguration('API_LIVE_KEY', '', 6, 1, $setFunctionFieldapiLiveKey);
         $this->addConfiguration('API_LIVE_SECRET', '', 6, 1, $setFunctionFieldapiLiveSecret);
 
-        xtc_db_query("CREATE TABLE `rth_stripe_php_session` (
-            `id` varchar(32) NOT NULL,
-            `created` datetime DEFAULT NULL,
-            `data` longtext DEFAULT NULL,
-            PRIMARY KEY (`id`)
-          );
-        ");
+        $repo = new Repository();
+        $repo->createRthStripePhpSession();
     }
 
     public function remove(): void

--- a/src/includes/modules/payment/payment_rth_stripe.php
+++ b/src/includes/modules/payment/payment_rth_stripe.php
@@ -113,6 +113,14 @@ class payment_rth_stripe extends PaymentModule
         $this->addConfiguration('API_SANDBOX_SECRET', '', 6, 1, $setFunctionFieldapiSandboxSecret);
         $this->addConfiguration('API_LIVE_KEY', '', 6, 1, $setFunctionFieldapiLiveKey);
         $this->addConfiguration('API_LIVE_SECRET', '', 6, 1, $setFunctionFieldapiLiveSecret);
+
+        xtc_db_query("CREATE TABLE `rth_stripe_php_session` (
+            `id` varchar(32) NOT NULL,
+            `created` datetime DEFAULT NULL,
+            `data` longtext DEFAULT NULL,
+            PRIMARY KEY (`id`)
+          );
+        ");
     }
 
     public function remove(): void


### PR DESCRIPTION
We need to save the current PHP session, as it may have already expired if the customer takes a long time with the Stripe payment process. When the PHP session times out, the customer has paid, but no order is placed in the shop.