### PR TITLE
fix: prevent losing the PHP session

### DIFF
--- a/src-mmlc/Classes/Controller/Controller.php
+++ b/src-mmlc/Classes/Controller/Controller.php
@@ -142,10 +142,9 @@ class Controller extends AbstractController
         }
     }
 
-    public function invokeCancel(): Response
+    public function invokeCancel(): void
     {
-        return new RedirectResponse('/checkout_confirmation.php');
-        //dd('The order could not be paid.');
+        dd('The order could not be paid.');
 
         // TODO: handle cancel
     }

--- a/src-mmlc/Classes/Controller/Controller.php
+++ b/src-mmlc/Classes/Controller/Controller.php
@@ -142,9 +142,10 @@ class Controller extends AbstractController
         }
     }
 
-    public function invokeCancel(): void
+    public function invokeCancel(): Response
     {
-        dd('The order could not be paid.');
+        return new RedirectResponse('/checkout_confirmation.php');
+        //dd('The order could not be paid.');
 
         // TODO: handle cancel
     }

--- a/src/includes/modules/payment/payment_rth_stripe.php
+++ b/src/includes/modules/payment/payment_rth_stripe.php
@@ -193,10 +193,16 @@ class payment_rth_stripe extends PaymentModule
      */
     public function selection(): array
     {
+        $selectionFieldArray = [
+            'title' => '',
+            'field' => xtc_draw_hidden_field(xtc_session_name(), xtc_session_id())
+        ];
+
         $selectionArray = [
             'id'          => $this->code,
             'module'      => 'Stripe (RobinTheHood)',
-            'description' => 'Zahle mit Stripe'
+            'description' => 'Zahle mit Stripe',
+            'fields'      => [$selectionFieldArray]
         ];
 
         return $selectionArray;

--- a/src/includes/modules/payment/payment_rth_stripe.php
+++ b/src/includes/modules/payment/payment_rth_stripe.php
@@ -231,7 +231,42 @@ class payment_rth_stripe extends PaymentModule
         // $session = new Session();
         // $session->setOrder($rthOrder);
 
-        return '';
+        //return '';
+
+        $htmlStr = xtc_draw_hidden_field(xtc_session_name(), xtc_session_id());
+
+        return $htmlStr;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function before_process(): void
+    {
+        require_once DIR_FS_INC . 'xtc_remove_order.inc.php';
+
+        /** @var int|false */
+        $tempOrderId = $_SESSION['tmp_oID'] ?? false;
+
+        if (!$tempOrderId) {
+            return;
+        }
+
+        if (!is_numeric($tempOrderId)) {
+            return;
+        }
+
+        $_SESSION['tmp_oID'] = null;
+
+        // TODO: maybe we should remove this order
+        $restockOrder    = true;
+        $reactiveProduct = true;
+        //xtc_remove_order(order_id: $tempOrderId, restock: $restockOrder, activate: $reactiveProduct);
+        xtc_remove_order($tempOrderId, restock: $restockOrder, activate: $reactiveProduct);
+        //xtc_remove_order($tempOrderId, $restockOrder, $reactiveProduct);
+
+        // unset($_SESSION['tmp_oID']);
+        xtc_redirect('checkout_confirmation.php');
     }
 
     /**

--- a/src/includes/modules/payment/payment_rth_stripe.php
+++ b/src/includes/modules/payment/payment_rth_stripe.php
@@ -231,42 +231,7 @@ class payment_rth_stripe extends PaymentModule
         // $session = new Session();
         // $session->setOrder($rthOrder);
 
-        //return '';
-
-        $htmlStr = xtc_draw_hidden_field(xtc_session_name(), xtc_session_id());
-
-        return $htmlStr;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function before_process(): void
-    {
-        require_once DIR_FS_INC . 'xtc_remove_order.inc.php';
-
-        /** @var int|false */
-        $tempOrderId = $_SESSION['tmp_oID'] ?? false;
-
-        if (!$tempOrderId) {
-            return;
-        }
-
-        if (!is_numeric($tempOrderId)) {
-            return;
-        }
-
-        $_SESSION['tmp_oID'] = null;
-
-        // TODO: maybe we should remove this order
-        $restockOrder    = true;
-        $reactiveProduct = true;
-        //xtc_remove_order(order_id: $tempOrderId, restock: $restockOrder, activate: $reactiveProduct);
-        xtc_remove_order($tempOrderId, restock: $restockOrder, activate: $reactiveProduct);
-        //xtc_remove_order($tempOrderId, $restockOrder, $reactiveProduct);
-
-        // unset($_SESSION['tmp_oID']);
-        xtc_redirect('checkout_confirmation.php');
+        return '';
     }
 
     /**


### PR DESCRIPTION
Prevent losing the PHP session by integrating the session id into the POST request

The problem was that "modified" provides its session cookies with Samesite `lax`.